### PR TITLE
In AppleAuthManager::getUserInfo, convert the AppleResourceOwner instance into SocialAuthUserInterface

### DIFF
--- a/src/AppleAuthManager.php
+++ b/src/AppleAuthManager.php
@@ -5,6 +5,7 @@ namespace Drupal\social_auth_apple;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\social_auth\AuthManager\OAuth2Manager;
+use Drupal\social_auth\User\SocialAuthUser;
 use Drupal\social_auth\User\SocialAuthUserInterface;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -67,7 +68,16 @@ class AppleAuthManager extends OAuth2Manager {
    */
   public function getUserInfo():? SocialAuthUserInterface {
     if (!$this->user) {
-      $this->user = $this->client->getResourceOwner($this->getAccessToken());
+      /** @var \League\OAuth2\Client\Provider\AppleResourceOwner $owner */
+      $owner = $this->client->getResourceOwner($this->getAccessToken());
+      $this->user = new SocialAuthUser(
+        strstr($owner->getEmail(), '@', true),
+        $owner->getId(),
+        $this->getAccessToken(),
+        $owner->getEmail(),
+      );
+      $this->user->setFirstName($owner->getFirstName());
+      $this->user->setLastName($owner->getLastName());
     }
 
     return $this->user;


### PR DESCRIPTION
When Apple POSTs to this module's callback URL, the request fails with this error:

> TypeError: Drupal\social_auth_apple\AppleAuthManager::getUserInfo(): Return value must be of type ?Drupal\social_auth\User\SocialAuthUserInterface, League\OAuth2\Client\Provider\AppleResourceOwner returned in Drupal\social_auth_apple\AppleAuthManager->getUserInfo()

This PR converts the AppleResourceOwner instance into SocialAuthUserInterface, enabling the login to complete successfully.